### PR TITLE
Replaced the throw error with a warning and added a return false.

### DIFF
--- a/src/VIPSoft/Unzip/Unzip.php
+++ b/src/VIPSoft/Unzip/Unzip.php
@@ -141,7 +141,9 @@ class Unzip
             return $filename;
         }
 
-        throw new \Exception('Invalid filename path in zip archive');
+        trigger_error("Invalid filename path in zip archive: {$filename}", E_USER_WARNING);
+        return FALSE;
+
     }
 
     /**


### PR DESCRIPTION
When a filename is invalid, it might be better to just warn instead of throwing an error that stops the whole process. In our case, we were OK with the missing / invalid files. 

Returning FALSE just ignores the missing files.